### PR TITLE
Add CI/CD pipelines for automated deployment to Azure Blob Storage

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -1,0 +1,23 @@
+name: Triggers Deployment on Pull Request Merge
+on:
+    pull_request:
+        types: [closed]
+        branches: [develop, staging, production]
+jobs:
+    on-merge:
+        if: github.event.pull_request.merged == true
+        runs-on: ubuntu-latest
+        outputs:
+             target_branch: ${{ steps.get_branch.outputs.branch_name }}
+        steps:
+            - name: Get the target branch
+              id: get_branch
+              run: echo "branch_name=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+
+    trigger-deploy-workflow:
+        needs: on-merge
+        uses: ./.github/workflows/deploy-to-blob.yml
+        with:
+            environment: ${{ needs.on-merge.outputs.target_branch }}
+            version: 'latest'
+        secrets: inherit

--- a/.github/workflows/deploy-to-blob.yml
+++ b/.github/workflows/deploy-to-blob.yml
@@ -1,0 +1,82 @@
+name: Release to Azure Blob Storage
+on:
+    workflow_dispatch:
+        inputs:
+            environment:
+                description: 'Environment to deploy to'
+                required: true
+                default: 'develop'
+                type: choice
+                options:
+                    - develop
+                    - staging
+                    - production
+            version:
+                description: 'Version to deploy'
+                required: true
+                default: 'latest'
+    workflow_call:
+        inputs:
+            environment:
+                description: 'Environment to deploy to'
+                required: true
+                default: 'develop'
+                type: string
+            version:
+                description: 'Version to deploy'
+                required: true
+                default: 'latest'
+                type: string
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ inputs.environment }}
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            # Infer the environment from the workflow input and set the appropriate environment variable
+            - name: Set the target container
+              run: |
+                    if [ "${{ inputs.environment }}" == "develop" ]; then
+                        echo "TARGET_CONTAINER=dev" >> $GITHUB_ENV
+                    elif [ "${{ inputs.environment }}" == "staging" ]; then
+                        echo "TARGET_CONTAINER=stage" >> $GITHUB_ENV
+                    elif [ "${{ inputs.environment }}" == "production" ]; then
+                        echo "TARGET_CONTAINER=prod" >> $GITHUB_ENV
+                    else
+                        echo "Invalid environment specified"
+                        exit 1
+                    fi
+
+            - name: Install dependencies
+              run: npm clean-install
+              env:
+                FORCE_COLOR: 2
+
+            - name: Build
+              run: npm run all
+              env:
+                FORCE_COLOR: 2
+
+            - name: Gather build artifacts
+              run: |
+                  mkdir -p build
+                  cp -r dist/* build/
+                  echo "Files in build directory:"
+                  ls -R build
+
+            - name: Upload to Azure Blob Storage
+              uses: LanceMcCarthy/Action-AzureBlobUpload@v3
+              with:
+                source_folder: 'build'
+                connection_string: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
+                container_name: 'pathways-editor'
+                destination_folder: '${{ env.TARGET_CONTAINER }}'
+                delete_if_exists: true


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to automate deployments of the pathways editor to Azure Blob Storage, mirroring the deployment setup used in the workspaces frontend repo.

### New workflows

**`deploy-to-blob.yml` — Release to Azure Blob Storage**
- Runs manually via `workflow_dispatch` (choose environment: `develop`, `staging`, `production`) or from another workflow via `workflow_call`
- Checks out the selected environment branch, builds the editor with Node 20 (`npm clean-install` + `npm run all`), and uploads the built `dist/` to the `pathways-editor` container
- Maps environments to destination folders: `develop` → `dev`, `staging` → `stage`, `production` → `prod`

**`deploy-on-merge.yml` — Trigger deployment on PR merge**
- Fires when a PR is merged into `develop`, `staging`, or `production`
- Calls the release workflow with the merged branch as the target environment